### PR TITLE
Fix error from MWSE.log

### DIFF
--- a/MM - Enhanced Detection/00 - Core/MWSE/mods/OperatorJack/EnhancedDetection/main.lua
+++ b/MM - Enhanced Detection/00 - Core/MWSE/mods/OperatorJack/EnhancedDetection/main.lua
@@ -40,13 +40,13 @@ local timerController = nil
 -- Register Event Handlers --
 local function onObjectInvalidated(e)
   local ref = e.object
-  for _, referenceController in pairs(referenceControllers) do
+  for _, referenceController in pairs(referenceControllers or {}) do
     if (referenceController.references[ref] == true) then
       referenceController.references[ref] = nil
     end
   end
 end
-event.register("objectInvalidated", onObjectInvalidated) 
+event.register("objectInvalidated", onObjectInvalidated)
 
 local effects = {
   [tes3.effect.detectAnimal] = true,


### PR DESCRIPTION
This should fix this kind of error that I got in the MWSE.log file.

```Lua
Error in event callback: ... Files\MWSE\mods\OperatorJack\EnhancedDetection\main.lua:43: bad argument #1 to 'pairs' (table expected, got nil)
stack traceback:
	.\Data Files\MWSE\core\lib\event.lua:167: in function <.\Data Files\MWSE\core\lib\event.lua:166>
	[C]: in function 'pairs'
	... Files\MWSE\mods\OperatorJack\EnhancedDetection\main.lua:43: in function <... Files\MWSE\mods\OperatorJack\EnhancedDetection\main.lua:41>
	[C]: in function 'xpcall'
	.\Data Files\MWSE\core\lib\event.lua:180: in function 'trigger'
	.\Data Files\MWSE\core\lib\event.lua:200: in function <.\Data Files\MWSE\core\lib\event.lua:170>

```